### PR TITLE
Process duplicates

### DIFF
--- a/compare_plaid_with_mint.py
+++ b/compare_plaid_with_mint.py
@@ -72,7 +72,7 @@ def main():
             "action" - "Duplicate" or blank
             "related_id" - id of the lunchmoney transaction in the plaid CSV output
     """
-    plaid_df = prepare_plaid_dataset(START_DATE, END_DATE, lmc.LM_CSV_FILE_BASE)
+    plaid_df = prepare_plaid_dataset(START_DATE, END_DATE)
     mint_df = prepare_mint_dataset(os.path.join(lmc.INPUT_FILES, lmc.MINT_CSV_FILE))
 
     # Read in the mapping of LM/Mint Account Name synonyms
@@ -139,7 +139,7 @@ def sort_by_account_date(df, acct_name, date):
     return sorted_df
 
 
-def prepare_plaid_dataset(start_date, end_date, lm_csv_file_base):
+def prepare_plaid_dataset(start_date, end_date):
     """This function reads or fetchs a set of lunchmoney transactions in the
     specified date range and transforms it into
     a dataframe, reducin low value columns while adding
@@ -152,7 +152,7 @@ def prepare_plaid_dataset(start_date, end_date, lm_csv_file_base):
     A side effect of this function is to write a csv file 'ignored_transactions.csv'
     which contains any transactions with a "source" value other than "plaid"
     """
-    df = trans.read_or_fetch_lm_transactions(start_date, end_date, lm_csv_file_base)
+    df = trans.read_or_fetch_lm_transactions(start_date, end_date)
     if "action" not in df.columns and "related_id" not in df.columns:
         # This a previously unprocessed data pull from LunchMoney,
         # Thin out the columns, add our analysis columns, and sort

--- a/config/lunchmoney_config_template.py
+++ b/config/lunchmoney_config_template.py
@@ -10,6 +10,17 @@
 LUNCHMONEY_API_TOKEN = "<YOUR_TOKEN_HERE>"
 
 ###################################
+# Cache File for read_or_fetch_lm_transactions in lib/transactions
+###################################
+# The name of the file to write lunchmoney transactions to that are fetched by the API
+# If this file exists, the data here will be used instead of making an API call
+# If not the API will append  _START-DATE_END-DATE.csv and write a cache for future requests
+# Delete this file, to force an API call, or call delete_transactions_cache()
+PATH_TO_TRANSACTIONS_CACHE = "/tmp/lm_transactions"
+
+###################################
+
+###################################
 # Default location for input and output files
 ###################################
 INPUT_FILES = "./input"
@@ -19,7 +30,12 @@ OUTPUT_FILES = "./output"
 # Variables used by get_new_transaction.py
 ###################################
 LOOKBACK_TRANSACTION_DAYS = 7
-LM_FETCHED_TRANSACTIONS_CACHE = "lm_transactions"
+###################################
+# Variables used by process_duplicates.py
+###################################
+# Number of days to look for duplicate transactions
+LOOKBACK_LM_DUP_DAYS = 7
+
 
 ###################################
 # Variables used by compare_plaid_with_mint.py
@@ -30,11 +46,11 @@ END_DATE_STR = "12/31/2023"
 # The name of the csv file with your mint transactions, in the INPUT_FILES directory
 MINT_CSV_FILE = "transactions.csv"
 # The format of the date strings in your Mint data
+# This is the format of the dates as exported by Mint and LunchMoney
 MINT_DATE_FORMAT = "%Y-%m-%d"
-# The name of the file to write lunchmoney transactions to that are fetched by the API
-# If this file exists, the data here will be used instead of making an API call
-# Delete this file, in the INPUT_FILES directory, to force an API call
-LM_CSV_FILE_BASE = "plaid_analyzed_transactions"
+# This is the format of dates once a CSV is opened and saved in Excel
+# MINT_DATE_FORMAT = "%m/%d/%y"
+
 # The date of plaid transactions in Lunchmoney is the transaction date
 # Mint dates are typically the transaction settle date so can be some days later
 # For at least one of my accounts I've seen the Mint dates be earlier than Plaid too.

--- a/lib/transactions.py
+++ b/lib/transactions.py
@@ -10,13 +10,17 @@
    Apps that access multiple lunchmoney APIs can pass in a pre-intialized lunchable
    client for API access.
 """
+
 import ast
 import os
 import pandas as pd
 import sys
 from lunchable import LunchMoney
 from lunchable.models import TransactionUpdateObject
-from config import lunchmoney_config as lmc
+from config.lunchmoney_config import (
+    LUNCHMONEY_API_TOKEN,
+    PATH_TO_TRANSACTIONS_CACHE
+)
 
 sys.path.append("..")
 
@@ -24,10 +28,13 @@ private_lunch = None
 categories = None
 
 
-def init_lunchable(token):
+def init_lunchable(token=None):
     global private_lunch
     if private_lunch is None:
-        private_lunch = LunchMoney(access_token=token)
+        if token is None:
+            private_lunch = LunchMoney(access_token=LUNCHMONEY_API_TOKEN)
+        else:
+            private_lunch = LunchMoney(access_token=token)
     return private_lunch
 
 
@@ -36,7 +43,7 @@ def lunchmoney_transactions_to_df(start_date, end_date, lunch=None):
     lunchable.get_transactions API for the specified data range
     """
     if lunch is None:
-        lunch = init_lunchable(lmc.LUNCHMONEY_API_TOKEN)
+        lunch = init_lunchable()
 
     # Fetch transactions from the last three months
     transactions = lunch.get_transactions(start_date, end_date)
@@ -47,16 +54,22 @@ def lunchmoney_transactions_to_df(start_date, end_date, lunch=None):
 
 
 def lunchmoney_update_transaction(id, transaction_fields, lunch=None):
-    """ Updated the transaction with id, to have whatever new values are
-        in set in the transaction_fields object
+    """Updated the transaction with id, to have whatever new values are
+    in set in the transaction_fields object
     """
     if lunch is None:
-        lunch = init_lunchable(lmc.LUNCHMONEY_API_TOKEN)
+        lunch = init_lunchable()
     update_object = TransactionUpdateObject(**transaction_fields)
     return lunch.update_transaction(id, update_object)
 
 
-def read_or_fetch_lm_transactions(start_date, end_date, csv_file_base, lunch=None):
+def read_or_fetch_lm_transactions(
+    start_date,
+    end_date,
+    remove_pending=False,
+    remove_split_parents=False,
+    lunch=None,
+):
     """Returns a dataframe of transactions from lunchmoney
 
     If the file csv_file_base-start_date-end_date.csv exists they
@@ -67,25 +80,81 @@ def read_or_fetch_lm_transactions(start_date, end_date, csv_file_base, lunch=Non
     be set to a token aquired from https://my.lunchmoney.app/developers
     """
     csv_file = os.path.join(
-        lmc.INPUT_FILES,
-        f"{csv_file_base}-{start_date.strftime('%Y_%m_%d')}-{end_date.strftime('%Y_%m_%d')}.csv",
+        f"{PATH_TO_TRANSACTIONS_CACHE}-{start_date.strftime('%Y_%m_%d')}-{end_date.strftime('%Y_%m_%d')}.csv",
     )
     if os.path.isfile(csv_file):
         # We have a cached version of the same transaction request written as a CSV
         # Read it in from the CSV converting the tags field to an array of objects and
         # the date field to a datatime object, just as they'd be returned by the API
-        converters = {'tags': lambda val: ast.literal_eval(val) if isinstance(val, str) else val}
-        df = pd.read_csv(csv_file, parse_dates=["date"], date_format="%Y-%m-%d", converters=converters)
-        df["date"] = pd.to_datetime(df["date"])
+        converters = {
+            "tags": lambda val: ast.literal_eval(val) if isinstance(val, str) else val
+        }
+        df = pd.read_csv(
+            csv_file,
+            parse_dates=["date"],
+            date_format="%Y-%m-%d",
+            converters=converters,
+        )
         print(f"Read {len(df)} transactions from {csv_file}.")
         print("Just delete this file if you want to re-fetch them again in the future.")
     else:
         print("Attempting to fetch your lunch money transactions via the API...")
         df = lunchmoney_transactions_to_df(start_date, end_date, lunch)
-        df["date"] = pd.to_datetime(df["date"])
         print(f"Got all {len(df)} of them.")
         print(f"Will write them to {csv_file} for faster future access.")
         print("Just delete this file if you want to re-fetch them again in the future.")
-        df.to_csv(csv_file, index=False)
+        try:
+            # Massage out any newlines in any of the fields
+            df = df.map(lambda x: x.replace('\n', ' ') if isinstance(x, str) else x)
+            df.to_csv(csv_file, index=False)
+        except Exception as e:
+            print(f"Failed to write to {csv_file}. Reason: {e}")
+            print("Please consider changing the value of PATH_TO_TRANSACTIONS_CACHE in the config file.")
+
+    # Ensure a workable datetime format, and clean up extra spaces LM puts in act names
+    df["date"] = pd.to_datetime(df["date"])
+    df["account_display_name"] = df["account_display_name"].str.strip()
+
+    if remove_pending:
+        df = remove_pending_transactions(df)
+    if remove_split_parents:
+        # remove any parents of split transactions
+        df = remove_parents_of_split_transactions(df)
 
     return df
+
+
+def remove_parents_of_split_transactions(df):
+    """ remove any parents of split transactions """
+    parents = df[df["has_children"]]
+    for parent_id in parents["id"]:
+        if parent_id not in df["parent_id"].values:
+            print(f"Parent id {parent_id} does not exist in the dataframe.")
+            sys.exit(1)
+    print(f"Removing {len(parents)} parents of transactions that were split")
+    return df[~df["has_children"]]
+
+
+def remove_pending_transactions(df):
+    """ remove any pending transactions """
+    all_trans = len(df)
+    df = df[~df.is_pending]
+    num_pending = all_trans - len(df)
+    print(f"Removing {num_pending} new transactions that are pending.")
+    return df
+
+
+def lunchmoney_delete_transaction(id, existing_tag_names):
+    """ Ideally this would removes the transactions with the id passed in
+        Since the LM API does not support the ability to delete transactions instead
+        we'll add a Duplicate tag that the user can filter on for manual deletion
+    """
+    # TODO Change this to really delete it when API becomes available
+    update_obj = {}
+    if existing_tag_names:
+        existing_tag_names += ",Duplicate"
+        update_obj["tags"] = existing_tag_names.split(",")
+    else:
+        update_obj["tags"] = ["Duplicate"]
+
+    lunchmoney_update_transaction(id, update_obj)

--- a/process_duplicates.py
+++ b/process_duplicates.py
@@ -1,0 +1,215 @@
+"""process_duplicate.py
+
+    This program analyzes a set of transactions from lunchmoney and indentifies
+    potential duplicates, displaying them to the user interactively.
+
+    If the user confirms that one or more of the transactions is a duplicate,
+    the program deletes the duplicate transactions.  
+
+    *** NOTE THE API DOES NOT YET SUPPORT TRANSACTION DELETION.
+        FOR NOW THE FUNCTION lunchmoney_delete_transaction() TAGS
+        TRANSACTIONS AS "DUPLICATE" SO THEY CAN BE EASILY DELETED IN THE GUI ***
+
+    If the user indicates that the transactions are each unique,
+    the transactions are given a tag "Not-Duplicate" to prevent them from being
+    flagged again in future runs
+
+    If any transactions are deleted/tagged as duplciates, they are written to an
+    output file for further examination
+"""
+import os
+from datetime import datetime
+import pandas as pd
+from lib.transactions import (
+    read_or_fetch_lm_transactions,
+    lunchmoney_update_transaction,
+    lunchmoney_delete_transaction,
+)
+from config.lunchmoney_config import START_DATE_STR, END_DATE_STR, LOOKBACK_LM_DUP_DAYS
+
+
+def main():
+    # Fetch the transactions from LunchMoney
+    df = read_or_fetch_lm_transactions(
+        datetime.strptime(START_DATE_STR, "%m/%d/%Y"),
+        datetime.strptime(END_DATE_STR, "%m/%d/%Y"),
+        remove_pending=True,
+        remove_split_parents=True,
+    )
+
+    dup_ids = find_duplicates_for_all_accounts(df, lookback_days=LOOKBACK_LM_DUP_DAYS)
+
+    if len(dup_ids):
+        # We found duplicate, write them to a CSV file to be examined
+        dup_df = df[df["id"].isin(dup_ids)]
+        today_date_str = datetime.now().strftime("%Y-%m-%d")
+        output_file_path = os.path.join(
+            "output", f"marked_as_duplicate_{today_date_str}.csv"
+        )
+        dup_df.to_csv(output_file_path, index=False)
+        print(f"Found {len(dup_df)} duplicates. Details written to: {output_file_path}")
+
+
+def find_duplicates_for_all_accounts(
+    df,
+    lookback_days=0,
+):
+    """ Break a dataframe of transactions into sets of transactions for the same
+        account.  Then pass that dataframe into a function to find duplicates
+
+        This approach makes it easier to pull up the financial institutions website
+        to validate suspected duplicate transactions
+    """
+    ids_to_delete = []
+    # To facilitate checking break the df into chunks based on account name
+    for account_name in df["account_display_name"].unique():
+        # Sort all the rows for each account by date, and make a copy to check for dups
+        df_to_search = df[df["account_display_name"] == account_name].sort_values(
+            by="date", ascending=False
+        )
+        ids_to_delete = find_duplicates_for_one_account(
+            df_to_search, lookback_days, ids_to_delete
+        )
+
+    return ids_to_delete
+
+
+def find_duplicates_for_one_account(df, lookback_days, ids_to_delete):
+    """Look for duplicates in a dataframe of transactions
+    If found ask user to disambiguate, tagging non-duplicates, and
+    deleteing duplicates
+
+    Note that it is assumed that all transactions are for the same account
+    """  # Validate: len(df_to_search["account_display_name"].unique())
+    deleted_indices = []
+    df_copy = df.copy()
+    for index, row in df.iterrows():
+        # Skip analysis if the row was already declared a duplciate
+        if index in deleted_indices:
+            continue
+        df_copy.drop(index, inplace=True)
+        # Find transactions with the same amount in the same date window
+        matches = df_copy[
+            (df_copy["amount"] == row["amount"])
+            # We assume that the data passed into this function is for a single acct
+            # & (df_copy["account_display_name"] == row["account_display_name"])
+            & (df_copy["date"] >= row.date - pd.Timedelta(days=lookback_days))
+        ]
+
+        # Drop matches that have already been marked Not-Duplicate
+        if len(matches) > 0:
+            not_duplicate_tags = {"Not-Duplicate", "SkipDupCheck"}
+            if any(tag["name"] in not_duplicate_tags for tag in row["tags"]):
+                matches = matches[
+                    ~matches["tags"].apply(
+                        lambda tags: any(
+                            tag["name"] in not_duplicate_tags for tag in tags
+                        )
+                    )
+                ]
+                if len(matches) <= 0:
+                    continue
+
+            # Combine row and matches to interactively check with the user
+            new_row = row.to_frame().T
+            matches = pd.concat([new_row, matches])
+
+            # Convert datetimes to printable date format
+            matches["date"] = matches["date"].apply(lambda x: x.strftime("%Y-%m-%d"))
+            # Convert list of tag objects to a string of comma seperated tag names
+            matches["tags"] = matches["tags"].apply(
+                lambda tags: ",".join([tag["name"] for tag in tags])
+            )
+            print("\nPotential duplicate transactions:")
+            while len(matches) > 1:
+                print(
+                    matches[
+                        [
+                            "date",
+                            "category_name",
+                            "payee",
+                            "amount",
+                            "account_display_name",
+                            "notes",
+                            "tags",
+                        ]
+                    ].to_string(index=True)
+                )
+                need_user_input = True
+                while need_user_input:
+                    user_response = input(
+                        "Please enter the index of any duplicate or hit enter if "
+                        "there are no duplicates: "
+                    )
+                    try:
+                        # If we got a numeric input delete the duplicate transaction
+                        dup_index = int(user_response)
+                        if dup_index != index and dup_index not in matches.index:
+                            print("Invalid entry try again.")
+                            continue
+                        print("Will delete this duplicate")
+                        id_to_delete = matches.loc[dup_index, "id"]
+                        ids_to_delete.append(id_to_delete)
+                        lunchmoney_delete_transaction(
+                            id_to_delete, matches.loc[dup_index, "tags"]
+                        )
+                        if dup_index != index:
+                            # Don't analyze this transaction when iterrate to it
+                            deleted_indices.append(dup_index)
+                            df_copy.drop(dup_index, inplace=True)
+                        matches.drop(dup_index, inplace=True)
+                        need_user_input = False
+                    except ValueError:
+                        # Add "Not-Duplicate" tag to transactions
+                        (df, df_copy) = interactive_tag_non_dup(matches, df, df_copy)
+                        matches = pd.DataFrame()
+                        need_user_input = False
+    return ids_to_delete
+
+
+def interactive_tag_non_dup(matches, loc_df1, loc_df2):
+    """Tags each transaction as the dataframe with "Not-Duplicate
+    Interactively offers opportunity to update Payee or Notes field
+    Updates transaction date in Lunch Money via API
+    Updates in mem copies of transactions for further processing
+    """
+    for index, match in matches.iterrows():
+        update_obj = {}
+        resp = input(
+            f"Tagging {index} as non duplicate.  Update Payee or Notes? (p/n/enter for no): "
+        )
+        if resp.lower() == "p":
+            resp2 = input("Enter new Payee text: ")
+            update_obj["payee"] = resp2
+        elif resp.lower() == "n":
+            resp2 = input("Enter new Notes text: ")
+            update_obj["notes"] = resp2
+        if "Not-Duplicate" not in match["tags"]:
+            if match["tags"]:
+                updated_tags = match["tags"] + ",Not-Duplicate"
+                update_obj["tags"] = (
+                    updated_tags.split(",") if "," in updated_tags else updated_tags
+                )
+                if "SkipDupCheck" in update_obj["tags"]:
+                    update_obj["tags"] = [
+                        tag for tag in update_obj["tags"] if tag != "SkipDupCheck"
+                    ]
+            else:
+                update_obj["tags"] = ["Not-Duplicate"]
+        if update_obj:
+            lunchmoney_update_transaction(
+                match["id"],
+                update_obj,
+            )
+
+        # Update local data stores so we don't do these again
+        if index in loc_df1.index:
+            loc_df1.loc[index, "tags"].append({"name": "SkipDupCheck"})
+        if index in loc_df2.index:
+            loc_df2.loc[index, "tags"].append({"name": "SkipDupCheck"})
+
+    return (loc_df1, loc_df2)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add process_duplicates.py to identify and remove duplicate lunchmoney transactions.

This commit also standardizes the way that transactions fetched by the API are cached on disk across all the different scripts that fetch transactions.